### PR TITLE
Ensure accurate queue retrieval in unique_at_runtime_redis_key

### DIFF
--- a/lib/resque/plugins/unique_at_runtime.rb
+++ b/lib/resque/plugins/unique_at_runtime.rb
@@ -43,8 +43,9 @@ module Resque
         # Overwrite this method to uniquely identify which mutex should be used
         # for a resque worker.
         def unique_at_runtime_redis_key(*_)
-          Resque::UniqueAtRuntime.debug("getting key for #{@queue}!")
-          @queue
+          queue = Resque.queue_from_class(self)
+          Resque::UniqueAtRuntime.debug("getting key for #{queue}!")
+          queue
         end
 
         # returns true if the job signature can be locked (is not currently locked)


### PR DESCRIPTION
https://github.com/resque/resque/blob/3a39c9b4e08e173484bb8b5a8afab65d4859e3d3/lib/resque.rb#L415-L420

Queues can be defined as instance methods and class methods.
You can retrieve the queue name without worrying about where it was defined by using Resque.queue_from_class(self).

----

https://github.com/resque/resque/blob/3a39c9b4e08e173484bb8b5a8afab65d4859e3d3/lib/resque.rb#L505-L508