### PR TITLE
Add flag to ensure `unlock_queue` is executed only once per job run

### DIFF
--- a/lib/resque/plugins/unique_at_runtime.rb
+++ b/lib/resque/plugins/unique_at_runtime.rb
@@ -71,9 +71,15 @@ module Resque
         end
 
         def unlock_queue(*args)
+          if @unlock_queue_executed
+            Resque::UniqueAtRuntime.debug('unlock queue already executed')
+            return
+          end
+
           key = unique_at_runtime_redis_key(*args)
           Resque::UniqueAtRuntime.debug("unlock queue with #{key}")
           Resque.redis.hdel(unique_at_runtime_key_base, key)
+          @unlock_queue_executed = true
         end
 
         def reenqueue(*args)
@@ -99,6 +105,8 @@ module Resque
         end
 
         def around_perform_unlock_runtime(*args)
+          @unlock_queue_executed = false
+
           yield
         ensure
           unlock_queue(*args)


### PR DESCRIPTION
fix https://github.com/resque/resque-unique_at_runtime/issues/194